### PR TITLE
Remove Bad and Unneeded Address

### DIFF
--- a/fund.html
+++ b/fund.html
@@ -15,8 +15,6 @@ layout: default-black
       Donate to the General Fund to show up on the <a href="/friends">Friends of Grin</a> page.
     </p>
     <h3>Donate</h3>
-    <small class="fund-donation-type">GRIN DONATION ADDRESS</small>
-    <a href="https://council-donations.yeastplume.org/" class="fund-address">https://council-donations.yeastplume.org</a>
     <small class="fund-donation-type">BITCOIN LEGACY</small>
     <a href="https://live.blockcypher.com/btc/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs/" class="fund-address">3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs</a>
     <small class="fund-donation-type">BITCOIN SEGWIT</small>


### PR DESCRIPTION
The 'Grin Donation Address' led to a yeastplume.org page which is invalid.  Suggest any replacement method be self hosted on grin.mw.